### PR TITLE
Refactored to use highlight namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,39 @@ I made this plugin so I could see which mode Neovim is in just by the color of C
     },
     opts = {
         -- you can set different blend values for your different modes.
-        -- Some colours might look better more dark.
-        blend = {
+        -- Some colours might look better more dark, so set a higher value
+        -- will result in a darker shade.
+        blends = {
             normal = 0.2,
             insert = 0.2,
-            visual = 0.3,
+            visual = 0.25,
             command = 0.2,
+            operator = 0.2,
             replace = 0.2,
-            select = 0.3,
+            select = 0.2,
             terminal = 0.2,
             terminal_n = 0.2,
         },
+        -- there are two ways to define colours for the different modes.
+        -- one way is to define theme here in colors. Another way is to
+        -- set them up with highlight groups. Any highlight group set takes
+        -- precedence over any colors defined here.
+        colors = {
+            normal = "#00BFFF",
+            insert = "#70CF67",
+            visual = "#AD6FF7",
+            command = "#EB788B",
+            operator = "#FF8F40",
+            replace = "#E66767",
+            select = "#AD6FF7",
+            terminal = "#4CD4BD",
+            terminal_n = "#00BBCC",
+        },
+        -- disable filetypes here. Add for example "TelescopePrompt" to
+        -- not have any coloured cursorline for the telescope prompt.
+        disabled_filetypes = {},
+        -- you can turn on or off bold characters for the line numbers
+        bold_nr = true,
     },
   }
 ```
@@ -58,6 +80,7 @@ I made this plugin so I could see which mode Neovim is in just by the color of C
     InsertMoody = { fg = C.green },
     VisualMoody = { fg = C.pink },
     CommandMoody = { fg = C.maroon },
+    OperatorMoody = { fg = C.maroon },
     ReplaceMoody = { fg = C.red },
     SelectMoody = { fg = C.pink },
     TerminalMoody = { fg = C.mauve },
@@ -68,18 +91,30 @@ I made this plugin so I could see which mode Neovim is in just by the color of C
 - Theres not a lot of values to set, but these are the defaults:
 ```lua
 {
-  blend = {
-    normal = 0.2,
-    insert = 0.2,
-    visual = 0.2,
-    command = 0.2,
-    replace = 0.2,
-    select = 0.2,
-    terminal = 0.2,
-    terminal_n = 0.2,
-  },
-  disabled_filetypes = {},
-  bold_nr = true,
+    blends = {
+        normal = 0.2,
+        insert = 0.2,
+        visual = 0.25,
+        command = 0.2,
+        operator = 0.2,
+        replace = 0.2,
+        select = 0.2,
+        terminal = 0.2,
+        terminal_n = 0.2,
+    },
+    colors = {
+        normal = "#00BFFF",
+        insert = "#70CF67",
+        visual = "#AD6FF7",
+        command = "#EB788B",
+        operator = "#FF8F40",
+        replace = "#E66767",
+        select = "#AD6FF7",
+        terminal = "#4CD4BD",
+        terminal_n = "#00BBCC",
+    },
+    disabled_filetypes = {},
+    bold_nr = true,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ I made this plugin so I could see which mode Neovim is in just by the color of C
         },
         -- disable filetypes here. Add for example "TelescopePrompt" to
         -- not have any coloured cursorline for the telescope prompt.
-        disabled_filetypes = {},
+        disabled_filetypes = { "TelescopePrompt" },
         -- you can turn on or off bold characters for the line numbers
         bold_nr = true,
     },

--- a/doc/moody.txt
+++ b/doc/moody.txt
@@ -15,10 +15,11 @@ moody.setup({options})                                         *moody.setup()*
 
     Defaults: ~
     {
-      blend = {
+      blends = {
         command = 0.2,
         insert = 0.2,
         normal = 0.2,
+        operator = 0.2,
         replace = 0.2,
         select = 0.2,
         terminal = 0.2,
@@ -26,6 +27,17 @@ moody.setup({options})                                         *moody.setup()*
         visual = 0.2
       },
       bold_nr = true,
+      colors = {
+        command = "#EB788B",
+        insert = "#70CF67",
+        normal = "#00BFFF",
+        operator = "#FF8F40",
+        replace = "#E66767",
+        select = "#AD6FF7",
+        terminal = "#4CD4BD",
+        terminal_n = "#00BBCC",
+        visual = "#AD6FF7"
+      },
       disabled_filetypes = {}
     }
 
@@ -63,11 +75,16 @@ Config                                                                *Config*
 
 
     Fields: ~
-        {blend}              (table)    how much to blend colors with black
+        {blends}             (Blends)   how much to blend colors with black
                                         for the cursorline
+        {colors}             (Colors)   table of colours with respective mode
         {disabled_filetypes} (table)    List of buffers to disable this plugin
                                         for
         {bold_nr}            (boolean)  bold linenumbers or not
+
+
+M.defaults()                                                    *M.defaults()*
+
 
 
 

--- a/doc/moody.txt
+++ b/doc/moody.txt
@@ -75,12 +75,9 @@ Config                                                                *Config*
 
 
     Fields: ~
-        {blends}             (Blends)   how much to blend colors with black
-                                        for the cursorline
-        {colors}             (Colors)   table of colours with respective mode
-        {disabled_filetypes} (table)    List of buffers to disable this plugin
-                                        for
-        {bold_nr}            (boolean)  bold linenumbers or not
+        {blends} (Blends)  how much to blend colors with black for the
+                           cursorline
+        {colors} (Colors)  table of colours with respective mode
 
 
 M.defaults()                                                    *M.defaults()*

--- a/lua/moody/config.lua
+++ b/lua/moody/config.lua
@@ -10,50 +10,18 @@ local function is_disabled_filetype(filetype)
   return vim.tbl_contains(disabled_filetypes, filetype) or string.match(filetype, "dapui")
 end
 
-local function set_hl_ns_cur_win()
-  vim.api.nvim_win_add_ns(vim.api.nvim_get_current_win(), M.ns_hl)
-  vim.api.nvim_set_hl_ns(M.ns_hl)
-end
-
----save highlights, also converts to hex string because reasons :)
-local function save_all_highlight()
-  local tohex = require("moody.math").int_to_hex_string
-  M.cursorline_hl = vim.api.nvim_get_hl(0, { name = "CursorLine" })
-  M.cursorlinenr_hl = vim.api.nvim_get_hl(0, { name = "CursorLineNr" })
-  M.visual = vim.api.nvim_get_hl(0, { name = "Visual" })
-  M.cursorline_bg = tohex(M.cursorline_hl.bg)
-  M.cursorline_fg = tohex(M.cursorline_hl.fg)
-  M.cursorlinenr_bg = tohex(M.cursorlinenr_hl.bg)
-  M.cursorlinenr_fg = tohex(M.cursorlinenr_hl.fg)
-  M.visual_bg = tohex(M.visual.bg)
-  M.visual_fg = tohex(M.visual.fg)
-end
-
----save visual
--- local function set_visual_highlight()
---   vim.api.nvim_set_hl(M.ns_hl, "Visual", { bg = M.options.hl_blended.visual })
--- end
-
----restore visual
--- local function restore_visual_highlight()
---   unset_hl_ns()
---   -- vim.api.nvim_set_hl(0, "Visual", { fg = M.visual.fg, bg = M.visual.bg })
--- end
-
----restore highlights
--- local function restore_all_highlight()
--- unset_hl_ns(vim.api.nvim_get_current_buf())
-
--- if not M.cursorline_hl or not M.cursorlinenr_hl or not M.visual then
---   return
--- end
--- vim.api.nvim_set_hl(M.ns_hl, "CursorLine", { fg = M.cursorline_hl.fg, bg = M.cursorline_hl.bg })
--- vim.api.nvim_set_hl(M.ns_hl, "CursorLineNr", {
---   fg = M.cursorlinenr_hl.fg,
---   bold = M.cursorlinenr_hl.bold,
---   bg = M.cursorlinenr_hl.bg,
--- })
--- vim.api.nvim_set_hl(M.ns_hl, "Visual", { fg = M.visual.fg, bg = M.visual.bg })
+-- ---save highlights, also converts to hex string because reasons :)
+-- local function save_all_highlight()
+--   local tohex = require("moody.math").int_to_hex_string
+--   M.cursorline_hl = vim.api.nvim_get_hl(0, { name = "CursorLine" })
+--   M.cursorlinenr_hl = vim.api.nvim_get_hl(0, { name = "CursorLineNr" })
+--   M.visual = vim.api.nvim_get_hl(0, { name = "Visual" })
+--   M.cursorline_bg = tohex(M.cursorline_hl.bg)
+--   M.cursorline_fg = tohex(M.cursorline_hl.fg)
+--   M.cursorlinenr_bg = tohex(M.cursorlinenr_hl.bg)
+--   M.cursorlinenr_fg = tohex(M.cursorlinenr_hl.fg)
+--   M.visual_bg = tohex(M.visual.bg)
+--   M.visual_fg = tohex(M.visual.fg)
 -- end
 
 local function cache_colors()
@@ -61,54 +29,6 @@ local function cache_colors()
   M.options.hl_unblended = utils.hl_unblended()
   M.options.hl_blended = utils.hl_blended(M.options.blends)
 end
-
--- ---unsets cursorline for certain window
--- ---@param win number
--- local function unset_cursorline_winid(win)
---   if vim.fn.win_gettype(win) == "" then
---     vim.api.nvim_set_option_value("cursorline", false, { scope = "local", win = win })
---   end
--- end
-
--- ---sets cursorline for certain window
--- ---@param win number
--- local function set_cursorline_winid(win)
---   if vim.fn.win_gettype(win) == "" then
---     vim.api.nvim_set_option_value("cursorline", true, { scope = "local", win = win })
---   end
--- end
-
--- local function set_cursorline_cur_win()
---   set_cursorline_winid(vim.api.nvim_get_current_win())
--- end
---
--- ---unsets cursorline for all windows
--- local function unset_cursorline_all()
---   local utils = require("moody.utils")
---
---   local window_list = vim.api.nvim_list_wins()
---   -- utils.P(window_list)
---   for _, win in ipairs(window_list) do
---     if vim.fn.win_gettype(win) == "" then
---       -- utils.P("is normal window")
---       vim.api.nvim_set_option_value("cursorline", false, { scope = "local", win = win })
---     end
---   end
--- end
---
--- ---sets cursorline for all windows
--- local function set_cursorline_all()
---   local utils = require("moody.utils")
---
---   local window_list = vim.api.nvim_list_wins()
---   utils.P(window_list)
---   for _, win in ipairs(window_list) do
---     if vim.fn.win_gettype(win) == "" then
---       utils.P("is normal window")
---       vim.api.nvim_set_option_value("cursorline", true, { scope = "local", win = win })
---     end
---   end
--- end
 
 ---@type Config
 M.defaults = {
@@ -178,9 +98,6 @@ function M.__setup(options)
 
   local augroup = vim.api.nvim_create_augroup("MoodyGroupModeChanged", { clear = true })
   M.ns_hl = vim.api.nvim_create_namespace("MoodyHighlightNS")
-
-  -- save the current hl groups changed, so they can be restored for disabled filetypes
-  save_all_highlight()
 
   -- load up the "colour caches"
   cache_colors()

--- a/lua/moody/config.lua
+++ b/lua/moody/config.lua
@@ -24,10 +24,53 @@ end
 --   M.visual_fg = tohex(M.visual.fg)
 -- end
 
-local function cache_colors()
+local function cache_colors_setup_highlighs()
   local utils = require("moody.utils")
   M.options.hl_unblended = utils.hl_unblended()
   M.options.hl_blended = utils.hl_blended(M.options.blends)
+
+  vim.api.nvim_set_hl(M.ns_normal, "CursorLine", { bg = M.options.hl_blended.normal })
+  vim.api.nvim_set_hl(M.ns_normal, "CursorLineNr", { fg = M.options.hl_unblended.normal, bold = M.options.bold_nr })
+
+  vim.api.nvim_set_hl(M.ns_insert, "CursorLine", { bg = M.options.hl_blended.insert })
+  vim.api.nvim_set_hl(M.ns_insert, "CursorLineNr", { fg = M.options.hl_unblended.insert, bold = M.options.bold_nr })
+
+  vim.api.nvim_set_hl(M.ns_visual, "Visual", { bg = M.options.hl_blended.visual })
+  vim.api.nvim_set_hl(M.ns_visual, "CursorLine", { bg = M.options.hl_blended.visual })
+  vim.api.nvim_set_hl(M.ns_visual, "CursorLineNr", { fg = M.options.hl_unblended.visual, bold = M.options.bold_nr })
+
+  vim.api.nvim_set_hl(M.ns_command, "CursorLine", { bg = M.options.hl_blended.command })
+  vim.api.nvim_set_hl(M.ns_command, "CursorLineNr", { fg = M.options.hl_unblended.command, bold = M.options.bold_nr })
+
+  vim.api.nvim_set_hl(M.ns_operator, "CursorLine", { bg = M.options.hl_blended.operator })
+  vim.api.nvim_set_hl(M.ns_operator, "CursorLineNr", { fg = M.options.hl_unblended.operator, bold = M.options.bold_nr })
+
+  vim.api.nvim_set_hl(M.ns_replace, "CursorLine", { bg = M.options.hl_blended.replace })
+  vim.api.nvim_set_hl(M.ns_replace, "CursorLineNr", { fg = M.options.hl_unblended.replace, bold = M.options.bold_nr })
+
+  vim.api.nvim_set_hl(M.ns_select, "CursorLine", { bg = M.options.hl_blended.select })
+  vim.api.nvim_set_hl(M.ns_select, "CursorLineNr", { fg = M.options.hl_unblended.select, bold = M.options.bold_nr })
+
+  vim.api.nvim_set_hl(M.ns_terminal, "CursorLine", { bg = M.options.hl_blended.terminal })
+  vim.api.nvim_set_hl(M.ns_terminal, "CursorLineNr", { fg = M.options.hl_unblended.terminal, bold = M.options.bold_nr })
+
+  vim.api.nvim_set_hl(M.ns_terminal_n, "CursorLine", { bg = M.options.hl_blended.terminal_n })
+  vim.api.nvim_set_hl(M.ns_terminal_n, "CursorLineNr", {
+    fg = M.options.hl_unblended.terminal_n,
+    bold = M.options.bold_nr,
+  })
+end
+
+local function setup_hl_namespaces()
+  M.ns_normal = vim.api.nvim_create_namespace("Moody_NORMAL_NS")
+  M.ns_insert = vim.api.nvim_create_namespace("Moody_INSERT_NS")
+  M.ns_visual = vim.api.nvim_create_namespace("Moody_VISUAL_NS")
+  M.ns_command = vim.api.nvim_create_namespace("Moody_COMMAND_NS")
+  M.ns_operator = vim.api.nvim_create_namespace("Moody_OPERATOR_NS")
+  M.ns_replace = vim.api.nvim_create_namespace("Moody_REPLACE_NS")
+  M.ns_select = vim.api.nvim_create_namespace("Moody_SELECT_NS")
+  M.ns_terminal = vim.api.nvim_create_namespace("Moody_TERMINAL_NS")
+  M.ns_terminal_n = vim.api.nvim_create_namespace("Moody_TERMINAL_N_NS")
 end
 
 ---@type Config
@@ -97,11 +140,12 @@ function M.__setup(options)
   local utils = require("moody.utils")
 
   local augroup = vim.api.nvim_create_augroup("MoodyGroupModeChanged", { clear = true })
-  M.ns_hl = vim.api.nvim_create_namespace("MoodyHighlightNS")
 
-  -- load up the "colour caches"
-  cache_colors()
-  vim.api.nvim_set_hl(M.ns_hl, "Visual", { bg = M.options.hl_blended.visual })
+  -- setup highlight namespaces for modes
+  setup_hl_namespaces()
+
+  -- load up the "colour caches" and setup highlights with it
+  cache_colors_setup_highlighs()
 
   -- A few cases where cursorline is needed to be set to not
   -- have a default gray line before any modes are enterd.
@@ -120,9 +164,9 @@ function M.__setup(options)
         return
       end
 
-      vim.api.nvim_set_hl(M.ns_hl, "CursorLine", { bg = M.options.hl_blended.normal })
-      vim.api.nvim_set_hl(M.ns_hl, "CursorLineNr", { fg = M.options.hl_unblended.normal, bold = M.options.bold_nr })
-      vim.api.nvim_set_hl_ns(M.ns_hl)
+      -- vim.api.nvim_set_hl(M.ns_hl, "CursorLine", { bg = M.options.hl_blended.normal })
+      -- vim.api.nvim_set_hl(M.ns_hl, "CursorLineNr", { fg = M.options.hl_unblended.normal, bold = M.options.bold_nr })
+      vim.api.nvim_set_hl_ns(M.ns_normal)
     end,
   })
 
@@ -142,95 +186,110 @@ function M.__setup(options)
       end
 
       -- use saved values as defaults
-      local blended = M.cursorline_bg
-      local unblended = M.cursorlinenr_fg
+      -- local blended
+      -- local unblended
 
       -- regex match with mode entered
       local mode = string.match(event.match, ".*:([^:]+)")
 
-      -- local debugText = "nothing"
+      local win = vim.api.nvim_get_current_win()
+
+      local debugText = "default"
 
       utils.switch(mode, {
         ["n"] = function()
-          -- debugText = "normal"
-          blended = M.options.hl_blended.normal
-          unblended = M.options.hl_unblended.normal
+          vim.api.nvim_win_set_hl_ns(win, M.ns_normal)
+          debugText = "normal"
+          -- blended = M.options.hl_blended.normal
+          -- unblended = M.options.hl_unblended.normal
         end,
         ["i"] = function()
-          -- debugText = "insert"
-          blended = M.options.hl_blended.insert
-          unblended = M.options.hl_unblended.insert
+          vim.api.nvim_win_set_hl_ns(win, M.ns_insert)
+          debugText = "insert"
+          -- blended = M.options.hl_blended.insert
+          -- unblended = M.options.hl_unblended.insert
         end,
         ["ix"] = function()
-          -- debugText = "insert-completion"
-          blended = M.options.hl_blended.insert
-          unblended = M.options.hl_unblended.insert
+          vim.api.nvim_win_set_hl_ns(win, M.ns_insert)
+          debugText = "insert-completion"
+          -- blended = M.options.hl_blended.insert
+          -- unblended = M.options.hl_unblended.insert
         end,
         ["v"] = function()
-          -- debugText = "visual"
-          blended = M.options.hl_blended.visual
-          unblended = M.options.hl_unblended.visual
+          vim.api.nvim_win_set_hl_ns(win, M.ns_visual)
+          debugText = "visual"
+          -- blended = M.options.hl_blended.visual
+          -- unblended = M.options.hl_unblended.visual
         end,
         ["V"] = function()
-          -- debugText = "visual-line"
-          blended = M.options.hl_blended.visual
-          unblended = M.options.hl_unblended.visual
+          vim.api.nvim_win_set_hl_ns(win, M.ns_visual)
+          debugText = "visual-line"
+          -- blended = M.options.hl_blended.visual
+          -- unblended = M.options.hl_unblended.visual
         end,
         [""] = function()
-          -- debugText = "visual-block"
-          blended = M.options.hl_blended.visual
-          unblended = M.options.hl_unblended.visual
+          vim.api.nvim_win_set_hl_ns(win, M.ns_visual)
+          debugText = "visual-block"
+          -- blended = M.options.hl_blended.visual
+          -- unblended = M.options.hl_unblended.visual
         end,
         ["c"] = function()
-          -- debugText = "command"
-          blended = M.options.hl_blended.command
-          unblended = M.options.hl_unblended.command
+          vim.api.nvim_win_set_hl_ns(win, M.ns_command)
+          debugText = "command"
+          -- blended = M.options.hl_blended.command
+          -- unblended = M.options.hl_unblended.command
         end,
         ["r"] = function()
-          -- debugText = "replace"
-          blended = M.options.hl_blended.replace
-          unblended = M.options.hl_unblended.replace
+          vim.api.nvim_win_set_hl_ns(win, M.ns_replace)
+          debugText = "replace"
+          -- blended = M.options.hl_blended.replace
+          -- unblended = M.options.hl_unblended.replace
         end,
         ["s"] = function()
-          -- debugText = "select"
-          blended = M.options.hl_blended.select
-          unblended = M.options.hl_unblended.select
+          vim.api.nvim_win_set_hl_ns(win, M.ns_select)
+          debugText = "select"
+          -- blended = M.options.hl_blended.select
+          -- unblended = M.options.hl_unblended.select
         end,
         ["t"] = function()
-          -- debugText = "terminal"
-          blended = M.options.hl_blended.terminal
-          unblended = M.options.hl_unblended.terminal
+          vim.api.nvim_win_set_hl_ns(win, M.ns_terminal)
+          debugText = "terminal"
+          -- blended = M.options.hl_blended.terminal
+          -- unblended = M.options.hl_unblended.terminal
         end,
         ["nt"] = function()
-          -- debugText = "terminal-normal"
-          blended = M.options.hl_blended.terminal_n
-          unblended = M.options.hl_unblended.terminal_n
+          vim.api.nvim_win_set_hl_ns(win, M.ns_terminal_n)
+          debugText = "normal-terminal"
+          -- blended = M.options.hl_blended.terminal_n
+          -- unblended = M.options.hl_unblended.terminal_n
         end,
         ["no"] = function()
-          -- debugText = "operator-pending"
-          blended = M.options.hl_blended.operator
-          unblended = M.options.hl_unblended.operator
+          vim.api.nvim_win_set_hl_ns(win, M.ns_operator)
+          debugText = "operator-pending"
+          -- blended = M.options.hl_blended.operator
+          -- unblended = M.options.hl_unblended.operator
         end,
         ["default"] = function()
-          -- debugText = "default"
-          blended = M.cursorline_hl.bg
-          unblended = M.cursorlinenr_hl.fg
+          vim.api.nvim_set_hl_ns(0)
+          debugText = "default"
+          -- blended = M.cursorline_hl.bg
+          -- unblended = M.cursorlinenr_hl.fg
         end,
       })()
 
       -- setup and print some debug data top cmdline
-      -- local debugdata = "mode is " .. mode .. " debugText is: " .. debugText
-      -- vim.cmd(string.format([[echo "%s"]], debugdata))
+      local debugdata = "mode is " .. mode .. " debugText is: " .. debugText
+      vim.cmd(string.format([[echo "%s"]], debugdata))
 
-      vim.api.nvim_set_hl(M.ns_hl, "CursorLine", { bg = blended })
-      vim.api.nvim_set_hl(M.ns_hl, "CursorLineNr", { fg = unblended, bold = M.options.bold_nr })
-      vim.api.nvim_set_hl_ns(M.ns_hl)
+      -- vim.api.nvim_set_hl(M.ns_hl, "CursorLine", { bg = blended })
+      -- vim.api.nvim_set_hl(M.ns_hl, "CursorLineNr", { fg = unblended, bold = M.options.bold_nr })
+      -- vim.api.nvim_set_hl_ns(M.ns_hl)
     end,
   })
 
   vim.api.nvim_create_autocmd({ "ColorScheme" }, {
     group = augroup,
-    callback = cache_colors,
+    callback = cache_colors_setup_highlighs,
   })
 
   vim.api.nvim_create_autocmd({ "VimEnter", "WinEnter", "BufWinEnter" }, {

--- a/lua/moody/config.lua
+++ b/lua/moody/config.lua
@@ -10,20 +10,6 @@ local function is_disabled_filetype(filetype)
   return vim.tbl_contains(disabled_filetypes, filetype) or string.match(filetype, "dapui")
 end
 
--- ---save highlights, also converts to hex string because reasons :)
--- local function save_all_highlight()
---   local tohex = require("moody.math").int_to_hex_string
---   M.cursorline_hl = vim.api.nvim_get_hl(0, { name = "CursorLine" })
---   M.cursorlinenr_hl = vim.api.nvim_get_hl(0, { name = "CursorLineNr" })
---   M.visual = vim.api.nvim_get_hl(0, { name = "Visual" })
---   M.cursorline_bg = tohex(M.cursorline_hl.bg)
---   M.cursorline_fg = tohex(M.cursorline_hl.fg)
---   M.cursorlinenr_bg = tohex(M.cursorlinenr_hl.bg)
---   M.cursorlinenr_fg = tohex(M.cursorlinenr_hl.fg)
---   M.visual_bg = tohex(M.visual.bg)
---   M.visual_fg = tohex(M.visual.fg)
--- end
-
 local function cache_colors_setup_highlighs()
   local utils = require("moody.utils")
   M.options.hl_unblended = utils.hl_unblended()
@@ -122,12 +108,10 @@ M.defaults = {
   bold_nr = true,
 }
 
----@alias MoodyFocus "window" | "neovim" | "both"
-
 ---@class Config
 ---@field blends Blends: how much to blend colors with black for the cursorline
 ---@field colors Colors: table of colours with respective mode
----@field disabled_filetypes table: List of buffers to disable this plugin for
+---@field disabled_filetypes table<string>: List of buffers to disable this plugin for
 ---@field bold_nr boolean: bold linenumbers or not
 M.options = {}
 
@@ -139,7 +123,7 @@ function M.__setup(options)
   M.options = vim.tbl_deep_extend("force", {}, M.defaults, options or {})
   local utils = require("moody.utils")
 
-  local augroup = vim.api.nvim_create_augroup("MoodyGroupModeChanged", { clear = true })
+  local augroup = vim.api.nvim_create_augroup("MoodyAuGroup", { clear = true })
 
   -- setup highlight namespaces for modes
   setup_hl_namespaces()
@@ -164,8 +148,6 @@ function M.__setup(options)
         return
       end
 
-      -- vim.api.nvim_set_hl(M.ns_hl, "CursorLine", { bg = M.options.hl_blended.normal })
-      -- vim.api.nvim_set_hl(M.ns_hl, "CursorLineNr", { fg = M.options.hl_unblended.normal, bold = M.options.bold_nr })
       vim.api.nvim_set_hl_ns(M.ns_normal)
     end,
   })
@@ -175,115 +157,77 @@ function M.__setup(options)
     desc = "set highlights depending on mode",
     group = augroup,
     callback = function(event)
-      -- utils.P(event)
-
-      -- utils.P("active window: " .. win_id)
-
       -- restore all highlights if disabled
       if is_disabled_filetype(vim.bo.filetype) then
         vim.api.nvim_set_hl_ns(0)
         return
       end
 
-      -- use saved values as defaults
-      -- local blended
-      -- local unblended
-
       -- regex match with mode entered
       local mode = string.match(event.match, ".*:([^:]+)")
 
       local win = vim.api.nvim_get_current_win()
 
-      local debugText = "default"
+      -- local debugText = "default"
 
       utils.switch(mode, {
         ["n"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_normal)
-          debugText = "normal"
-          -- blended = M.options.hl_blended.normal
-          -- unblended = M.options.hl_unblended.normal
+          -- debugText = "normal"
         end,
         ["i"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_insert)
-          debugText = "insert"
-          -- blended = M.options.hl_blended.insert
-          -- unblended = M.options.hl_unblended.insert
+          -- debugText = "insert"
         end,
         ["ix"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_insert)
-          debugText = "insert-completion"
-          -- blended = M.options.hl_blended.insert
-          -- unblended = M.options.hl_unblended.insert
+          -- debugText = "insert-completion"
         end,
         ["v"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_visual)
-          debugText = "visual"
-          -- blended = M.options.hl_blended.visual
-          -- unblended = M.options.hl_unblended.visual
+          -- debugText = "visual"
         end,
         ["V"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_visual)
-          debugText = "visual-line"
-          -- blended = M.options.hl_blended.visual
-          -- unblended = M.options.hl_unblended.visual
+          -- debugText = "visual-line"
         end,
         [""] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_visual)
-          debugText = "visual-block"
-          -- blended = M.options.hl_blended.visual
-          -- unblended = M.options.hl_unblended.visual
+          -- debugText = "visual-block"
         end,
         ["c"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_command)
-          debugText = "command"
-          -- blended = M.options.hl_blended.command
-          -- unblended = M.options.hl_unblended.command
+          -- debugText = "command"
         end,
         ["r"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_replace)
-          debugText = "replace"
-          -- blended = M.options.hl_blended.replace
-          -- unblended = M.options.hl_unblended.replace
+          -- debugText = "replace"
         end,
         ["s"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_select)
-          debugText = "select"
-          -- blended = M.options.hl_blended.select
-          -- unblended = M.options.hl_unblended.select
+          -- debugText = "select"
         end,
         ["t"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_terminal)
-          debugText = "terminal"
-          -- blended = M.options.hl_blended.terminal
-          -- unblended = M.options.hl_unblended.terminal
+          -- debugText = "terminal"
         end,
         ["nt"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_terminal_n)
-          debugText = "normal-terminal"
-          -- blended = M.options.hl_blended.terminal_n
-          -- unblended = M.options.hl_unblended.terminal_n
+          -- debugText = "normal-terminal"
         end,
         ["no"] = function()
           vim.api.nvim_win_set_hl_ns(win, M.ns_operator)
-          debugText = "operator-pending"
-          -- blended = M.options.hl_blended.operator
-          -- unblended = M.options.hl_unblended.operator
+          -- debugText = "operator-pending"
         end,
         ["default"] = function()
           vim.api.nvim_set_hl_ns(0)
-          debugText = "default"
-          -- blended = M.cursorline_hl.bg
-          -- unblended = M.cursorlinenr_hl.fg
+          -- debugText = "default"
         end,
       })()
 
       -- setup and print some debug data top cmdline
-      local debugdata = "mode is " .. mode .. " debugText is: " .. debugText
-      vim.cmd(string.format([[echo "%s"]], debugdata))
-
-      -- vim.api.nvim_set_hl(M.ns_hl, "CursorLine", { bg = blended })
-      -- vim.api.nvim_set_hl(M.ns_hl, "CursorLineNr", { fg = unblended, bold = M.options.bold_nr })
-      -- vim.api.nvim_set_hl_ns(M.ns_hl)
+      -- local debugdata = "mode is " .. mode .. " debugText is: " .. debugText
+      -- vim.cmd(string.format([[echo "%s"]], debugdata))
     end,
   })
 
@@ -292,13 +236,13 @@ function M.__setup(options)
     callback = cache_colors_setup_highlighs,
   })
 
+  -- only show cursorline in active window
   vim.api.nvim_create_autocmd({ "VimEnter", "WinEnter", "BufWinEnter" }, {
     group = augroup,
     callback = function()
       vim.wo.cursorline = true
     end,
   })
-
   vim.api.nvim_create_autocmd({ "WinLeave", "BufLeave" }, {
     group = augroup,
     callback = function()

--- a/lua/moody/utils.lua
+++ b/lua/moody/utils.lua
@@ -142,4 +142,3 @@ function M.P(v)
 end
 
 return M
-

--- a/lua/moody/utils.lua
+++ b/lua/moody/utils.lua
@@ -1,29 +1,33 @@
 local M = {}
 
 local darken = require("moody.math").darken
+
 local tohex = require("moody.math").int_to_hex_string
+local options = require("moody.config").options
 
 --- switch between string choice in table of string key, and table value choices
 --- A default case is not mandatory, but it will return nil if there is none :P
+--- The return should be a function, what to execute on choice
 --- @param choice string: The "case", key in your table of choices
 --- @param choices table: The "value", in your table of case keys
---- @return table value choices.choice case
+--- @return function value choices.choice case
 function M.switch(choice, choices)
   return choices[choice] or choices["default"]
 end
 
 ---comment
----@return table
+---@return Colors
 function M.hl_unblended()
   return {
-    normal = tohex(vim.api.nvim_get_hl(0, { name = "NormalMoody" }).fg),
-    insert = tohex(vim.api.nvim_get_hl(0, { name = "InsertMoody" }).fg),
-    visual = tohex(vim.api.nvim_get_hl(0, { name = "VisualMoody" }).fg),
-    command = tohex(vim.api.nvim_get_hl(0, { name = "CommandMoody" }).fg),
-    replace = tohex(vim.api.nvim_get_hl(0, { name = "ReplaceMoody" }).fg),
-    select = tohex(vim.api.nvim_get_hl(0, { name = "SelectMoody" }).fg),
-    terminal = tohex(vim.api.nvim_get_hl(0, { name = "TerminalMoody" }).fg),
-    terminal_n = tohex(vim.api.nvim_get_hl(0, { name = "TerminalNormalMoody" }).fg),
+    normal = tohex(vim.api.nvim_get_hl(0, { name = "NormalMoody" }).fg) or options.colors.normal,
+    insert = tohex(vim.api.nvim_get_hl(0, { name = "InsertMoody" }).fg) or options.colors.insert,
+    visual = tohex(vim.api.nvim_get_hl(0, { name = "VisualMoody" }).fg) or options.colors.visual,
+    command = tohex(vim.api.nvim_get_hl(0, { name = "CommandMoody" }).fg) or options.colors.command,
+    operator = tohex(vim.api.nvim_get_hl(0, { name = "OperatorMoody" }).fg) or options.colors.operator,
+    replace = tohex(vim.api.nvim_get_hl(0, { name = "ReplaceMoody" }).fg) or options.colors.replace,
+    select = tohex(vim.api.nvim_get_hl(0, { name = "SelectMoody" }).fg) or options.colors.select,
+    terminal = tohex(vim.api.nvim_get_hl(0, { name = "TerminalMoody" }).fg) or options.colors.terminal,
+    terminal_n = tohex(vim.api.nvim_get_hl(0, { name = "TerminalNormalMoody" }).fg) or options.colors.terminal_n,
   }
 end
 
@@ -37,7 +41,7 @@ end
 --- get darkened variant of the HL colours
 --- @param blend table|number: number: a number between 0 and 1 used to darken.
 --- table: a table of modes with their respective blend
---- @return table: a table of all the modes with values of blended colors
+--- @return Colors: a table of all the modes with values of blended colors
 function M.hl_blended(blend)
   local blend_type = type(blend)
   if blend_type == "table" then
@@ -46,6 +50,7 @@ function M.hl_blended(blend)
       insert = darken(M.hl_unblended().insert, blend.insert),
       visual = darken(M.hl_unblended().visual, blend.visual),
       command = darken(M.hl_unblended().command, blend.command),
+      operator = darken(M.hl_unblended().operator, blend.operator),
       replace = darken(M.hl_unblended().replace, blend.replace),
       select = darken(M.hl_unblended().select, blend.select),
       terminal = darken(M.hl_unblended().terminal, blend.terminal),
@@ -58,6 +63,7 @@ function M.hl_blended(blend)
         insert = darken(M.hl_unblended().insert, blend),
         visual = darken(M.hl_unblended().visual, blend),
         command = darken(M.hl_unblended().command, blend),
+        operator = darken(M.hl_unblended().operator, blend),
         replace = darken(M.hl_unblended().replace, blend),
         select = darken(M.hl_unblended().select, blend),
         terminal = darken(M.hl_unblended().terminal, blend),
@@ -65,73 +71,74 @@ function M.hl_blended(blend)
       }
     else
       return {
-        normal = darken(M.hl_unblended().normal, 0.3),
-        insert = darken(M.hl_unblended().insert, 0.3),
-        visual = darken(M.hl_unblended().visual, 0.3),
-        command = darken(M.hl_unblended().command, 0.3),
-        replace = darken(M.hl_unblended().replace, 0.3),
-        select = darken(M.hl_unblended().select, 0.3),
-        terminal = darken(M.hl_unblended().terminal, 0.3),
-        terminal_n = darken(M.hl_unblended().terminal_n, 0.3),
+        normal = darken(M.hl_unblended().normal, 0.2),
+        insert = darken(M.hl_unblended().insert, 0.2),
+        visual = darken(M.hl_unblended().visual, 0.2),
+        command = darken(M.hl_unblended().command, 0.2),
+        operator = darken(M.hl_unblended().operator, 0.2),
+        replace = darken(M.hl_unblended().replace, 0.2),
+        select = darken(M.hl_unblended().select, 0.2),
+        terminal = darken(M.hl_unblended().terminal, 0.2),
+        terminal_n = darken(M.hl_unblended().terminal_n, 0.2),
       }
     end
   end
 end
 
----callback for use with the autocommand for mode change
----@param blended table: table of blended mode colours
----@param unblended table: table of unblended mode colours
----@param bold_nr boolean: use bold chars for CursorLineNr
-function M.hl_callback(blended, unblended, bold_nr)
-  if vim.fn.win_gettype() == "" then
-    M.switch(vim.api.nvim_get_mode().mode, {
-      ["n"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.normal })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.normal, bold = bold_nr })
-      end,
-      ["i"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.insert })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.insert, bold = bold_nr })
-      end,
-      ["v"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.visual })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.visual, bold = bold_nr })
-      end,
-      ["V"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.visual })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.visual, bold = bold_nr })
-      end,
-      [""] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.visual })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.visual, bold = bold_nr })
-      end,
-      ["x"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.visual })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.visual, bold = bold_nr })
-      end,
-      ["c"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.command })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.command, bold = bold_nr })
-      end,
-      ["r"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.replace })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.replace, bold = bold_nr })
-      end,
-      ["s"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.select })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.select, bold = bold_nr })
-      end,
-      ["t"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.terminal })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.terminal, bold = bold_nr })
-      end,
-      ["default"] = function()
-        vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.terminal_n })
-        vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.terminal_n, bold = bold_nr })
-      end,
-    })()
-  end
-end
+-- ---callback for use with the autocommand for mode change
+-- ---@param blended table: table of blended mode colours
+-- ---@param unblended table: table of unblended mode colours
+-- ---@param bold_nr boolean: use bold chars for CursorLineNr
+-- function M.hl_callback(blended, unblended, bold_nr)
+--   if vim.fn.win_gettype() == "" then
+--     M.switch(vim.api.nvim_get_mode().mode, {
+--       ["n"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.normal })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.normal, bold = bold_nr })
+--       end,
+--       ["i"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.insert })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.insert, bold = bold_nr })
+--       end,
+--       ["v"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.visual })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.visual, bold = bold_nr })
+--       end,
+--       ["V"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.visual })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.visual, bold = bold_nr })
+--       end,
+--       [""] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.visual })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.visual, bold = bold_nr })
+--       end,
+--       ["x"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.visual })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.visual, bold = bold_nr })
+--       end,
+--       ["c"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.command })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.command, bold = bold_nr })
+--       end,
+--       ["r"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.replace })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.replace, bold = bold_nr })
+--       end,
+--       ["s"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.select })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.select, bold = bold_nr })
+--       end,
+--       ["t"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.terminal })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.terminal, bold = bold_nr })
+--       end,
+--       ["default"] = function()
+--         vim.api.nvim_set_hl(0, "CursorLine", { bg = blended.terminal_n })
+--         vim.api.nvim_set_hl(0, "CursorLineNr", { fg = unblended.terminal_n, bold = bold_nr })
+--       end,
+--     })()
+--   end
+-- end
 
 --- short hand method for printing stuff in neovim
 --- @param v any


### PR DESCRIPTION
Refactored the code to use highlight namespaces instead of changing the global highlight with every mode change. 

This fixes issues with for example Trouble, which would get a coloured CursorLine, which was not working as intended.

Also included the ability to set colours for different modes through the opts, or config. HighlightGroups will still take precedence over those colours, but if no highlight groups are set then those colours will be used. There are default colours if not set.